### PR TITLE
test require statements now work on case-sensitive platforms

### DIFF
--- a/tests/MapDiff.test.js
+++ b/tests/MapDiff.test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var diff = require('../src/diff');
-var Immutable = require('Immutable');
+var Immutable = require('immutable');
 var JSC = require('jscheck');
 var assert = require('assert');
 

--- a/tests/comparisonTests.test.js
+++ b/tests/comparisonTests.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var Immutable = require('Immutable');
+var Immutable = require('immutable');
 var assert = require('assert');
 var diff = require('../src/diff');
 var jsonDiff = require('jsondiff');

--- a/tests/lcs.test.js
+++ b/tests/lcs.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var Immutable = require('Immutable');
+var Immutable = require('immutable');
 var lcs = require('../src/lcs');
 var assert = require('assert');
 

--- a/tests/primitiveTypeDiff.test.js
+++ b/tests/primitiveTypeDiff.test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var diff = require('../src/diff');
-var Immutable = require('Immutable');
+var Immutable = require('immutable');
 var JSC = require('jscheck');
 var assert = require('assert');
 

--- a/tests/sequenceDiff.test.js
+++ b/tests/sequenceDiff.test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var diff = require('../src/diff');
-var Immutable = require('Immutable');
+var Immutable = require('immutable');
 var JSC = require('jscheck');
 var assert = require('assert');
 


### PR DESCRIPTION
Hey there! Thanks for the awesome library - its been a godsend in a project I'm working on. I ran into a small problem, though - we're using immutablediff both client-side and server-side, and while OSX isn't case-sensitive, other OSs (notably Ubuntu in this case) are. Most of the tests had `require('Immutable')` instead of `require('immutable')` in them, and that was causing some problems in deployment. Hope you don't mind the quick fix PR :)