### PR TITLE
Include old values in 'replace' ops.

### DIFF
--- a/src/diff.js
+++ b/src/diff.js
@@ -33,7 +33,7 @@ var mapDiff = function(a, b, p){
           var bValue = b.get ? b.get(aKey) : b;
           var areDifferentValues = (aValue !== bValue);
           if (areDifferentValues) {
-            ops.push(op('replace', concatPath(path, escape(aKey)), bValue));
+            ops.push(op('replace', concatPath(path, escape(aKey)), bValue, aValue));
           }
         }
       }
@@ -46,7 +46,7 @@ var mapDiff = function(a, b, p){
         else{
           ops.push( op('remove', concatPath(path, escape(aKey))) );
         }
-        
+
       }
     });
   }
@@ -78,7 +78,7 @@ var sequenceDiff = function (a, b, p) {
         ops = ops.concat(mapDiffs);
       }
       else{
-        ops.push(op('replace', concatPath(path, pathIndex), diff.newVal));
+        ops.push(op('replace', concatPath(path, pathIndex), diff.newVal, diff.val));
       }
       pathIndex++;
     }
@@ -96,13 +96,13 @@ var primitiveTypeDiff = function (a, b, p) {
   var path = p || '';
   if(a === b){ return []; }
   else{
-    return [ op('replace', concatPath(path, ''), b) ];
+    return [ op('replace', concatPath(path, ''), b, a) ];
   }
 };
 
 var diff = function(a, b, p){
   if(Immutable.is(a, b)){ return Immutable.List(); }
-  if(a != b && (a == null || b == null)){ return Immutable.fromJS([op('replace', '/', b)]); }
+  if(a != b && (a == null || b == null)){ return Immutable.fromJS([op('replace', '/', b, a)]); }
   if(isIndexed(a) && isIndexed(b)){
     return Immutable.fromJS(sequenceDiff(a, b));
   }

--- a/src/utils.js
+++ b/src/utils.js
@@ -5,10 +5,14 @@ var Immutable = require('immutable');
 var isMap = function(obj){ return Immutable.Iterable.isKeyed(obj); };
 var isIndexed = function(obj) { return Immutable.Iterable.isIndexed(obj); };
 
-var op = function(operation, path, value){
-  if(operation === 'remove') { return { op: operation, path: path }; }
-
-  return { op: operation, path: path, value: value };
+function op(operation, path, value, oldValue) {
+  if (operation === 'remove') {
+    return { op: operation, path: path };
+  } else if (operation === 'replace') {
+    return { op: operation, path: path, value: value, oldValue: oldValue};
+  } else {
+    return { op: operation, path: path, value: value};
+  }
 };
 
 module.exports = {

--- a/tests/MapDiff.test.js
+++ b/tests/MapDiff.test.js
@@ -76,7 +76,7 @@ describe('Map diff', function(){
         var map2 = Immutable.fromJS(obj).set('key', newValue);
 
         var result = diff(map1, map2);
-        var expected = Immutable.fromJS([{op: 'replace', path: '/key', value: newValue}]);
+        var expected = Immutable.fromJS([{op: 'replace', path: '/key', value: newValue, oldValue: obj.key}]);
 
         return veredict(Immutable.is(result, expected));
       },
@@ -139,7 +139,7 @@ describe('Map diff', function(){
         var map2 = Immutable.fromJS(obj).setIn(['b', 'c'], obj2.c);
 
         var result = diff(map1, map2);
-        var expected = Immutable.fromJS([{op: 'replace', path: '/b/c', value: obj2.c}]);
+        var expected = Immutable.fromJS([{op: 'replace', path: '/b/c', value: obj2.c, oldValue: obj.b.c}]);
 
         return veredict(Immutable.is(result, expected));
       },
@@ -187,7 +187,7 @@ describe('Map diff', function(){
         var map2 = Immutable.fromJS(obj).set('a', obj2.a);
 
         var result = diff(map1, map2);
-        var expected = Immutable.fromJS([{op: 'replace', path: '/a', value: obj2.a}]);
+        var expected = Immutable.fromJS([{op: 'replace', path: '/a', value: obj2.a, oldValue: obj.a}]);
 
         return veredict(Immutable.is(result, expected));
       },
@@ -291,7 +291,7 @@ describe('Map diff', function(){
 
         var result = diff(map1, map2);
         var expected = Immutable.fromJS([
-          {op: 'replace', path: '/b/c/'+replaceIdx, value: newValue}
+          {op: 'replace', path: '/b/c/'+replaceIdx, value: newValue, oldValue: obj.b.c[replaceIdx]}
         ]);
 
         return veredict(Immutable.is(result, expected));
@@ -328,7 +328,7 @@ describe('Map diff', function(){
       var map2 = Immutable.fromJS({a: 1});
 
       var result = diff(map1, map2);
-      var expected = Immutable.fromJS([{op: 'replace', path: '/', value: map2}]);
+      var expected = Immutable.fromJS([{op: 'replace', path: '/', value: map2, oldValue: null}]);
 
       assert.ok(Immutable.is(result, expected));
     });
@@ -338,7 +338,7 @@ describe('Map diff', function(){
       var map2 = null;
 
       var result = diff(map1, map2);
-      var expected = Immutable.fromJS([{op: 'replace', path: '/', value: map2}]);
+      var expected = Immutable.fromJS([{op: 'replace', path: '/', value: map2, oldValue: map1}]);
 
       assert.ok(Immutable.is(result, expected));
     });
@@ -348,7 +348,7 @@ describe('Map diff', function(){
       var map2 = Immutable.fromJS({a: 1});
 
       var result = diff(map1, map2);
-      var expected = Immutable.fromJS([{op: 'replace', path: '/a', value: 1}]);
+      var expected = Immutable.fromJS([{op: 'replace', path: '/a', value: 1, oldValue: null}]);
 
       assert.ok(Immutable.is(result, expected));
     });
@@ -383,7 +383,7 @@ describe('Map diff', function(){
 
       var result = diff(map1, map2);
       var expected = Immutable.fromJS([
-        {op: 'replace', path: '/b/prop~1prop', value: 10}
+        {op: 'replace', path: '/b/prop~1prop', value: 10, oldValue: 4}
       ]);
 
       assert.ok(Immutable.is(result, expected));
@@ -432,7 +432,7 @@ describe('Map diff', function(){
 
     var result = diff(map1, map2);
     var expected = Immutable.fromJS([
-      { op: 'replace', path: '/a', value: Immutable.fromJS({ b: 3 }) }
+      { op: 'replace', path: '/a', value: Immutable.fromJS({ b: 3 }), oldValue: false }
     ]);
 
     assert.ok(Immutable.is(result, expected));
@@ -444,7 +444,7 @@ describe('Map diff', function(){
 
     var result = diff(map1, map2);
     var expected = Immutable.fromJS([
-      { op: 'replace', path: '/a', value: false }
+      { op: 'replace', path: '/a', value: false, oldValue: {b: 3} }
     ]);
 
     assert.ok(Immutable.is(result, expected));

--- a/tests/comparisonTests.test.js
+++ b/tests/comparisonTests.test.js
@@ -10,6 +10,10 @@ var compareDiffs = function(a, b){
   var immutableDiffResult = diff(Immutable.fromJS(a), Immutable.fromJS(b));
 
   if (!Immutable.is(jsonDiffResult, immutableDiffResult)) {
+    // jsonDiff doesn't provide oldValue
+    // so make sure the only differences between the diffs is the addition
+    // of 'oldValue' fields, and trust the rest of the test suite to verify
+    // that the correct oldValue values are present.
     const diffDiff = diff(jsonDiffResult, immutableDiffResult);
     diffDiff.forEach(op => {
       if (op.get('op') !== 'add' ||

--- a/tests/comparisonTests.test.js
+++ b/tests/comparisonTests.test.js
@@ -9,7 +9,16 @@ var compareDiffs = function(a, b){
   var jsonDiffResult = Immutable.fromJS(jsonDiff.diff(a, b));
   var immutableDiffResult = diff(Immutable.fromJS(a), Immutable.fromJS(b));
 
-  assert.ok(Immutable.is(jsonDiffResult, immutableDiffResult));
+  if (!Immutable.is(jsonDiffResult, immutableDiffResult)) {
+    const diffDiff = diff(jsonDiffResult, immutableDiffResult);
+    diffDiff.forEach(op => {
+      if (op.get('op') !== 'add' ||
+          op.get('path').split('/').pop() !== 'oldValue') {
+        assert.ok(false);
+      }
+    })
+  }
+  assert.ok(true);
 };
 
 describe('Comparison Tests', function() {
@@ -33,11 +42,11 @@ describe('Comparison Tests', function() {
     compareDiffs([2, 3], [1, 2, 3]);
     compareDiffs([1, 3], [1, 2, 3]);
     compareDiffs([1, 2], [1, 2, 3]);
-    compareDiffs([1, 2, 3], [1, 4, 3]); 
+    compareDiffs([1, 2, 3], [1, 4, 3]);
 
     compareDiffs({a: [9, 8, 7], b: 2, c: 3}, {a: [9, 7], b: 2, c: 4, d: 5});
 
-    compareDiffs([1, 0, 0], [1, 1, 0]); 
+    compareDiffs([1, 0, 0], [1, 1, 0]);
     compareDiffs([1, 1, 0], [1, 0, 0]);
 
     compareDiffs({foo: 'bar'}, {baz: 'qux', foo: 'bar'});
@@ -48,6 +57,6 @@ describe('Comparison Tests', function() {
     compareDiffs({foo: 'bar'}, {foo: 'bar', child: {grandchild: {}}});
     compareDiffs({foo: ['bar']}, {foo: ['bar', ['abc', 'def']]});
 
-    compareDiffs([0, 0], [1, 1]); 
+    compareDiffs([0, 0], [1, 1]);
   });
 });

--- a/tests/primitiveTypeDiff.test.js
+++ b/tests/primitiveTypeDiff.test.js
@@ -44,7 +44,7 @@ describe('Primitive types diff', function() {
       function(veredict, int1, int2){
         var result = diff(int1, int2);
         var expected = Immutable.fromJS([
-          {op: 'replace', path: '/', value: int2}
+          {op: 'replace', path: '/', value: int2, oldValue: int1}
         ]);
 
         return veredict(Immutable.is(result, expected));
@@ -60,7 +60,7 @@ describe('Primitive types diff', function() {
       function(veredict, str1, str2){
         var result = diff(str1, str2);
         var expected = Immutable.fromJS([
-          {op: 'replace', path: '/', value: str2}
+          {op: 'replace', path: '/', value: str2, oldValue: str1}
         ]);
 
         return veredict(Immutable.is(result, expected));
@@ -76,7 +76,7 @@ describe('Primitive types diff', function() {
       function(veredict, array1, array2){
         var result = diff(array1, array2);
         var expected = Immutable.fromJS([
-          {op: 'replace', path: '/', value: array2}
+          {op: 'replace', path: '/', value: array2, oldValue: array1}
         ]);
 
         return veredict(Immutable.is(result, expected));
@@ -92,7 +92,7 @@ describe('Primitive types diff', function() {
       function(veredict, object1, object2){
         var result = diff(object1, object2);
         var expected = Immutable.fromJS([
-          {op: 'replace', path: '/', value: object2}
+          {op: 'replace', path: '/', value: object2, oldValue: object1}
         ]);
 
         return veredict(Immutable.is(result, expected));

--- a/tests/sequenceDiff.test.js
+++ b/tests/sequenceDiff.test.js
@@ -68,8 +68,8 @@ describe('Sequence diff', function() {
 
     var result = diff(list1, list2);
     var expected = Immutable.fromJS([
-      {op: 'replace', path: '/2', value: 4},
-      {op: 'replace', path: '/3', value: 5}
+      {op: 'replace', path: '/2', value: 4, oldValue: 3},
+      {op: 'replace', path: '/3', value: 5, oldValue: 4}
     ]);
 
     assert.ok(Immutable.is(result, expected));
@@ -91,11 +91,11 @@ describe('Sequence diff', function() {
     var list2 = Immutable.Range(1, 900).concat(Immutable.Range(950, 955));
 
     var expected = Immutable.List([
-      Immutable.Map({ op: "replace", path: "/899", value: 950 }),
-      Immutable.Map({ op: "replace", path: "/900", value: 951 }),
-      Immutable.Map({ op: "replace", path: "/901", value: 952 }),
-      Immutable.Map({ op: "replace", path: "/902", value: 953 }),
-      Immutable.Map({ op: "replace", path: "/903", value: 954 })
+      Immutable.Map({ op: "replace", path: "/899", value: 950, oldValue: 900 }),
+      Immutable.Map({ op: "replace", path: "/900", value: 951, oldValue: 901 }),
+      Immutable.Map({ op: "replace", path: "/901", value: 952, oldValue: 902 }),
+      Immutable.Map({ op: "replace", path: "/902", value: 953, oldValue: 903 }),
+      Immutable.Map({ op: "replace", path: "/903", value: 954, oldValue: 904 })
     ]).concat(Immutable.Repeat(Immutable.Map({ op: 'remove', path: '/904' }), 95));
 
     console.log(result);
@@ -173,7 +173,7 @@ describe('Sequence diff', function() {
 
         var result = diff(list1, modifiedList);
         var expected = Immutable.fromJS([
-          {op: 'replace', path: '/'+replaceIdx, value: newValue}
+          {op: 'replace', path: '/'+replaceIdx, value: newValue, oldValue: array[replaceIdx]}
         ]);
 
         return veredict(Immutable.is(result, expected));
@@ -217,7 +217,7 @@ describe('Sequence diff', function() {
 
         var result = diff(list1, modifiedList);
         var expected = Immutable.fromJS([
-          {op: 'replace', path: '/'+idx, value: newValue}
+          {op: 'replace', path: '/'+idx, value: newValue, oldValue: array[idx]}
         ]);
 
         return veredict(Immutable.is(result, expected));
@@ -235,7 +235,7 @@ describe('Sequence diff', function() {
 
     setDiff = diff(Immutable.Set([1]), Immutable.Set([1,2,3]));
     var expected = Immutable.fromJS([
-      {op: 'replace', path: '/', value: Immutable.Set([1,2,3])}
+      {op: 'replace', path: '/', value: Immutable.Set([1,2,3]), oldValue: Immutable.Set([1])}
     ]);
 
     assert.ok(Immutable.is(setDiff, expected));


### PR DESCRIPTION
Hi,

First of all, thanks for the great work on this lib 👌 . Not sure if you have any interest in this PR, but it satisfies my use case and I figure it can't hurt to offer.

My use case is as follows: I'm using immutable-js-diff to find out what's changed in a app state tree, and then notify registered listeners if anything pertinent to their interests has changed. Quite a few of the listeners want to know the previous value of the thing that changed, and enabling that manually was becoming a real headache.

The change is simply that e.g. 

``` js
diff(fromJS({a: 0}), fromJS({a: 1}));
// => List [ Map { "op": "replace", "path": "/a", "value": 1 } ]
```

becomes

``` js
diff(fromJS({a: 0}), fromJS({a: 1}));
// => List [ Map { "op": "replace", "path": "/a", "value": 1, "oldValue": 0 } ]
```

This _could_ be a breaking change for some people, so no offence will be taken if you laugh me out of the room.
