### PR TITLE
Add immutable to peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "jscheck": "^0.2.0",
     "jsondiff": "brenoferreira/json-diff"
   },
-  "dependencies": {
-    "immutable": "^3.2.1"
+  "peerDependencies": {
+    "immutable": "*"
   }
 }


### PR DESCRIPTION
- it ensures that the original Immutable version of the project using this library is used rather

We found this change necessary to solve this issue
https://github.com/rt2zz/redux-persist-transform-immutable/issues/22

Since this library deals with data immutable data structures build outside the library it must accept Immutable as a peerDependency.